### PR TITLE
Enable Dependabot dependency updates and Trivy Image scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(update)"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,47 @@
+name: Trivy Scan
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 12 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get image information
+        id: get-image-info
+        run: |
+          IMAGE_NAME=$(jq -r '.name' docker/package.json)
+          IMAGE_VERSION=$(jq -r '.version' docker/package.json)
+          echo $IMAGE_NAME
+          echo $IMAGE_VERSION
+          echo "IMAGE=quay.io/okdp/$IMAGE_NAME:$IMAGE_VERSION" >> $GITHUB_ENV
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        with:
+          image-ref: '${{ env.IMAGE }}'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Enable Dependabot dependency updates for the project's repository and store the results in the project's repository "Vulnerabilities" section.

Added the .github/dependabot.yml file with the necessary configuration for daily dependency scans.

Follows up https://github.com/OKDP/hive-metastore/issues/18

Dependabot automatic pullrequest example:
![image](https://github.com/user-attachments/assets/997ae19c-df3a-45ec-8a4f-7db00366299a)

***
Enable daily Trivy image scan and store the reports in the project's repository "Code Scanning" section.

Added the .github/workflows/trivy.yml file with the necessary configuration for daily Docker image scans.

Follows up https://github.com/OKDP/hive-metastore/issues/20