### PR TITLE
Hive metastore 4x

### DIFF
--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -47,3 +47,61 @@ jobs:
     uses: okdp/gh-workflows/.github/workflows/docker-publish-template.yml@v1
     secrets: inherit
 
+### Build and publish the hive-metastore 4.x version ###
+
+  build-and-publish-metastore-4x:
+    needs: rebuild-docker-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      ### Get additional 4.x metastore version
+
+      - name: Parse metastore_v4x.yaml for version
+        id: extract_version
+        run: |
+          LABEL=$(grep '"version"' docker/package.json | head -n 1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+          SUFFIX=$(echo "$LABEL" | awk -F'-' '{if (NF>1) print $2; else print ""}')
+          echo "$SUFFIX"
+          VERSION=$(grep 'ARG_METASTORE_VERSION' metastore_4x.yaml | head -n 1 | sed 's/.*ARG_METASTORE_VERSION=//')
+          echo "argument=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION-$SUFFIX"
+          echo "version=$VERSION-$SUFFIX" >> $GITHUB_OUTPUT
+
+      ### Common steps between CI and Publish
+      
+      - name: Free up disk space 📦
+        uses: okdp/gh-workflows/.github/actions/free-disk-space@v1
+
+      - name: Set up QEMU and Docker Buildx 📦
+        uses: okdp/gh-workflows/.github/actions/setup-buildx@v1
+
+      - name: Set up container registry 📦
+        id: registry
+        run:  |
+            echo "registry=${{ vars.REGISTRY || inputs.registry }}" >> $GITHUB_OUTPUT
+            echo "registry_repo=${{ vars.REGISTRY || inputs.registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+      
+      - name: Login into ${{ steps.registry.outputs.registry }} registry 🔐
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ steps.registry.outputs.registry }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_ROBOT_TOKEN }}
+
+      - name: Build and Push Docker image with ARG_METASTORE_VERSION=${{ steps.extract_version.outputs.version }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.registry.outputs.registry_repo }}/okdp-hive-metastore:${{ steps.extract_version.outputs.version }}
+          labels: |
+            org.opencontainers.image.version="${{ steps.extract_version.outputs.version }}"
+            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+            org.opencontainers.image.licenses="Apache-2.0"
+          build-args: |
+            ARG_METASTORE_VERSION=${{ steps.extract_version.outputs.argument }}
+            METASTORE_SERVER="-server"

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -64,7 +64,7 @@ jobs:
           LABEL=$(grep '"version"' docker/package.json | head -n 1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
           SUFFIX=$(echo "$LABEL" | awk -F'-' '{if (NF>1) print $2; else print ""}')
           echo "$SUFFIX"
-          VERSION=$(grep 'ARG_METASTORE_VERSION' metastore_4x.yaml | head -n 1 | sed 's/.*ARG_METASTORE_VERSION=//')
+          VERSION=$(grep 'ARG_METASTORE_VERSION' docker/metastore_4x.version | head -n 1 | sed 's/.*ARG_METASTORE_VERSION=//')
           echo "argument=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION-$SUFFIX"
           echo "version=$VERSION-$SUFFIX" >> $GITHUB_OUTPUT
@@ -104,4 +104,3 @@ jobs:
             org.opencontainers.image.licenses="Apache-2.0"
           build-args: |
             ARG_METASTORE_VERSION=${{ steps.extract_version.outputs.argument }}
-            METASTORE_SERVER="-server"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,6 @@ FROM eclipse-temurin:19-jre-focal
 
 ARG ARG_HADOOP_VERSION=3.4.1
 ARG ARG_METASTORE_VERSION=3.1.3
-ARG METASTORE_SERVER
 ARG ARG_JDBC_VERSION=42.7.7
 ARG MYSQL_CONNECTOR_VERSION=8.0.25
 ARG ARG_MYSQL_CLIENT_VERSION=8.0.42-0ubuntu0.20.04.1
@@ -39,7 +38,13 @@ RUN apt-get update && \
 
 WORKDIR /opt
 
-RUN curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore${METASTORE_SERVER}/${METASTORE_VERSION}/hive-standalone-metastore${METASTORE_SERVER}-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -
+#RUN curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/${METASTORE_VERSION}/hive-standalone-metastore-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -
+
+RUN if echo $METASTORE_VERSION | grep -E '^3\.' > /dev/null; then \
+        curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/${METASTORE_VERSION}/hive-standalone-metastore-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -; \
+    elif echo $METASTORE_VERSION | grep -E '^4\.' > /dev/null; then \
+        curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore-server-${METASTORE_VERSION}/hive-standalone-metastore-server-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -; \
+    fi
 
 # dlcdn.apache.org is faster, but does not provide 3.2.0 version. So fallback on archive.apache.org
 #RUN curl -L https://dlcdn.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar zxf - && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,12 +7,13 @@
 #  NB: Got jdbc issue with FROM eclipse-temurin:8u402-b06-jre-alpine
 #
 FROM eclipse-temurin:19-jre-focal
-#FROM eclipse-temurin:8-jre-noble
 
-ARG ARG_HADOOP_VERSION=3.2.0
+ARG ARG_HADOOP_VERSION=3.4.1
 ARG ARG_METASTORE_VERSION=3.1.3
-ARG ARG_JDBC_VERSION=42.7.3
+ARG METASTORE_SERVER
+ARG ARG_JDBC_VERSION=42.7.7
 ARG MYSQL_CONNECTOR_VERSION=8.0.25
+ARG ARG_MYSQL_CLIENT_VERSION=8.0.42-0ubuntu0.20.04.1
 ARG LOG4J_SCANNER_VERSION=2.9.1
 ARG JMX_PROMETHEUS_JAVAAGENT_VERSION=1.0.1
 ARG JMX_PORT=9025
@@ -20,7 +21,7 @@ ARG JMX_PORT=9025
 ENV HADOOP_VERSION=$ARG_HADOOP_VERSION
 ENV METASTORE_VERSION=$ARG_METASTORE_VERSION
 ENV JDBC_VERSION=$ARG_JDBC_VERSION
-ENV MYSQL_CLIENT_VERSION="8.0.42-0ubuntu0.20.04.1"
+ENV MYSQL_CLIENT_VERSION=$ARG_MYSQL_CLIENT_VERSION
 
 ENV HADOOP_HOME=/opt/hadoop-${HADOOP_VERSION}
 ENV HIVE_HOME=/opt/apache-hive-metastore-${METASTORE_VERSION}-bin
@@ -32,12 +33,13 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     postgresql-client \
     sudo \
+    curl \
     mysql-client=${MYSQL_CLIENT_VERSION} && \
     apt-get clean -y
 
 WORKDIR /opt
 
-RUN curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/${METASTORE_VERSION}/hive-standalone-metastore-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -
+RUN curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore${METASTORE_SERVER}/${METASTORE_VERSION}/hive-standalone-metastore${METASTORE_SERVER}-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -
 
 # dlcdn.apache.org is faster, but does not provide 3.2.0 version. So fallback on archive.apache.org
 #RUN curl -L https://dlcdn.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar zxf - && \
@@ -46,23 +48,22 @@ RUN curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metas
 RUN curl -L https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar zxf - && \
     rm -f hadoop-${HADOOP_VERSION}/share/hadoop/common/lib/slf4j-log4j12-*.jar
 
-RUN curl -L https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar -o /opt/apache-hive-metastore-${METASTORE_VERSION}-bin/lib/postgresql-${JDBC_VERSION}.jar
+RUN rm -f ${HIVE_HOME}/lib/postgresql-*.jar && \
+    curl -L https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar -o /opt/apache-hive-metastore-${METASTORE_VERSION}-bin/lib/postgresql-${JDBC_VERSION}.jar
 
 # download and install mysql-connector-java
-RUN curl -sLO "https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar" --output mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar \
+RUN curl -LO https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar --output mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar \
     && mv mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar ${HIVE_HOME}/lib/
 
 # download the log4shell scanner and run it on different paths
-RUN curl -sLO "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/${LOG4J_SCANNER_VERSION}/log4j-core-${LOG4J_SCANNER_VERSION}.jar" \
-
+RUN curl -LO https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/${LOG4J_SCANNER_VERSION}/log4j-core-${LOG4J_SCANNER_VERSION}.jar \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /usr/lib || true \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /var/lib || true \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /opt || true \
     && rm log4j-core-${LOG4J_SCANNER_VERSION}.jar
 
 # add the Prometheus JMX exporter Java agent jar for exposing metrics
-RUN curl -sLO "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_PROMETHEUS_JAVAAGENT_VERSION}/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar" \
-
+RUN curl -LO https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_PROMETHEUS_JAVAAGENT_VERSION}/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar \
     && mkdir /prometheus \
     && mv jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar /prometheus/ \
     && chmod 644 /prometheus/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,12 +38,10 @@ RUN apt-get update && \
 
 WORKDIR /opt
 
-#RUN curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/${METASTORE_VERSION}/hive-standalone-metastore-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -
-
 RUN if echo $METASTORE_VERSION | grep -E '^3\.' > /dev/null; then \
         curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/${METASTORE_VERSION}/hive-standalone-metastore-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -; \
     elif echo $METASTORE_VERSION | grep -E '^4\.' > /dev/null; then \
-        curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore-server-${METASTORE_VERSION}/hive-standalone-metastore-server-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -; \
+        curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore-server/${METASTORE_VERSION}/hive-standalone-metastore-server-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -; \
     fi
 
 # dlcdn.apache.org is faster, but does not provide 3.2.0 version. So fallback on archive.apache.org

--- a/docker/metastore_4x.version
+++ b/docker/metastore_4x.version
@@ -1,0 +1,2 @@
+metastore_version:
+  - ARG_METASTORE_VERSION=4.0.1


### PR DESCRIPTION
This pull request provides the addition of a new hive-metastore docker image based on the latest version(v4.0.1) of the hive-metastore tool. 

The Github docker workflow now supports multi-build with two docker images for v3.1.3 and v.4.0.1.

A new file "metastore_4x.version" was added inside the docker directory in order to provide the possibility to pass a build argument to the second build-and-push stage of the Github workflow.

Follows up #45 