### PR TITLE
Hive metastore noble

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17-jre-noble
 
 ARG ARG_HADOOP_VERSION=3.3.6
 ARG ARG_METASTORE_VERSION=3.1.3
-ARG ARG_JDBC_VERSION=42.7.6
+ARG ARG_JDBC_VERSION=42.7.7
 ARG MYSQL_CONNECTOR_VERSION=8.0.25
 ARG ARG_MYSQL_CLIENT_VERSION=8.0.42-0ubuntu0.24.04.1
 ARG LOG4J_SCANNER_VERSION=2.25.0
@@ -40,21 +40,22 @@ RUN if echo $METASTORE_VERSION | grep -E '^3\.' > /dev/null; then \
 RUN curl -L https://dlcdn.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar zxf - && \
     sed -i 's|if \[\[ ! -x "\$JAVA" \]\]; then|if [ \$("$JAVA" -version) ]; then|' ${HADOOP_HOME}/libexec/hadoop-functions.sh
 
-RUN curl -sL https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar -o /opt/apache-hive-metastore-${METASTORE_VERSION}-bin/lib/postgresql-${JDBC_VERSION}.jar
+RUN rm -f ${HIVE_HOME}/lib/postgresql-*.jar && \ 
+    curl -sL https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar -o /opt/apache-hive-metastore-${METASTORE_VERSION}-bin/lib/postgresql-${JDBC_VERSION}.jar
 
 # download and install mysql-connector-java
 RUN curl -sLO "https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar" --output mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar \
     && mv mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar ${HIVE_HOME}/lib/
 
 # download the log4shell scanner and run it on different paths
-RUN curl -sLO "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/${LOG4J_SCANNER_VERSION}/log4j-core-${LOG4J_SCANNER_VERSION}.jar" \
+RUN curl -sLO https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/${LOG4J_SCANNER_VERSION}/log4j-core-${LOG4J_SCANNER_VERSION}.jar \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /usr/lib || true \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /var/lib || true \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /opt || true \
     && rm log4j-core-${LOG4J_SCANNER_VERSION}.jar
 
 # add the Prometheus JMX exporter Java agent jar for exposing metrics
-RUN curl -sLO "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_PROMETHEUS_JAVAAGENT_VERSION}/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar" \
+RUN curl -sLO https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_PROMETHEUS_JAVAAGENT_VERSION}/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar \
     && mkdir /opt/prometheus \
     && mv jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar /opt/prometheus/ \
     && chmod 644 /opt/prometheus/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,11 @@
-# Take reference From:
-#   https://github.com/apache/spark-docker
-#   3.5.0/scala2.12-java11-ubuntu/Dockerfile
-#
-#  https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=11-jre-focal
-#
-#  NB: Got jdbc issue with FROM eclipse-temurin:8u402-b06-jre-alpine
-#
-FROM eclipse-temurin:19-jre-focal
+FROM eclipse-temurin:17-jre-noble
 
-ARG ARG_HADOOP_VERSION=3.4.1
+ARG ARG_HADOOP_VERSION=3.3.6
 ARG ARG_METASTORE_VERSION=3.1.3
-ARG ARG_JDBC_VERSION=42.7.7
+ARG ARG_JDBC_VERSION=42.7.6
 ARG MYSQL_CONNECTOR_VERSION=8.0.25
-ARG ARG_MYSQL_CLIENT_VERSION=8.0.42-0ubuntu0.20.04.1
-ARG LOG4J_SCANNER_VERSION=2.9.1
+ARG ARG_MYSQL_CLIENT_VERSION=8.0.42-0ubuntu0.24.04.1
+ARG LOG4J_SCANNER_VERSION=2.25.0
 ARG JMX_PROMETHEUS_JAVAAGENT_VERSION=1.0.1
 ARG JMX_PORT=9025
 
@@ -44,49 +36,45 @@ RUN if echo $METASTORE_VERSION | grep -E '^3\.' > /dev/null; then \
         curl -L https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore-server/${METASTORE_VERSION}/hive-standalone-metastore-server-${METASTORE_VERSION}-bin.tar.gz | tar xvzf -; \
     fi
 
-# dlcdn.apache.org is faster, but does not provide 3.2.0 version. So fallback on archive.apache.org
-#RUN curl -L https://dlcdn.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar zxf - && \
-#    rm -f hadoop-${HADOOP_VERSION}/share/hadoop/common/lib/slf4j-log4j12-*.jar
+# download and install hadoop and fix the (>= ubuntu jammy) distribution executable bug
+RUN curl -L https://dlcdn.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar zxf - && \
+    sed -i 's|if \[\[ ! -x "\$JAVA" \]\]; then|if [ \$("$JAVA" -version) ]; then|' ${HADOOP_HOME}/libexec/hadoop-functions.sh
 
-RUN curl -L https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar zxf - && \
-    rm -f hadoop-${HADOOP_VERSION}/share/hadoop/common/lib/slf4j-log4j12-*.jar
-
-RUN rm -f ${HIVE_HOME}/lib/postgresql-*.jar && \
-    curl -L https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar -o /opt/apache-hive-metastore-${METASTORE_VERSION}-bin/lib/postgresql-${JDBC_VERSION}.jar
+RUN curl -sL https://jdbc.postgresql.org/download/postgresql-${JDBC_VERSION}.jar -o /opt/apache-hive-metastore-${METASTORE_VERSION}-bin/lib/postgresql-${JDBC_VERSION}.jar
 
 # download and install mysql-connector-java
-RUN curl -LO https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar --output mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar \
+RUN curl -sLO "https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar" --output mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar \
     && mv mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar ${HIVE_HOME}/lib/
 
 # download the log4shell scanner and run it on different paths
-RUN curl -LO https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/${LOG4J_SCANNER_VERSION}/log4j-core-${LOG4J_SCANNER_VERSION}.jar \
+RUN curl -sLO "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/${LOG4J_SCANNER_VERSION}/log4j-core-${LOG4J_SCANNER_VERSION}.jar" \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /usr/lib || true \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /var/lib || true \
     && java -jar log4j-core-${LOG4J_SCANNER_VERSION}.jar --scan-log4j1 --scan-zip --scan-logback --force-fix /opt || true \
     && rm log4j-core-${LOG4J_SCANNER_VERSION}.jar
 
 # add the Prometheus JMX exporter Java agent jar for exposing metrics
-RUN curl -LO https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_PROMETHEUS_JAVAAGENT_VERSION}/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar \
-    && mkdir /prometheus \
-    && mv jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar /prometheus/ \
-    && chmod 644 /prometheus/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar
+RUN curl -sLO "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_PROMETHEUS_JAVAAGENT_VERSION}/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar" \
+    && mkdir /opt/prometheus \
+    && mv jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar /opt/prometheus/ \
+    && chmod 644 /opt/prometheus/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar
 
-COPY docker/config.yaml /prometheus
+COPY docker/config.yaml /opt/prometheus
 
 COPY docker/metastore.sh /metastore.sh
 
-RUN groupadd -r hive --gid=1000 && \
-    useradd -r -g hive --uid=1000 -d ${HIVE_HOME} hive && \
+RUN groupadd -r hive --gid=996 && \
+    useradd -r -g hive --uid=996 -d ${HIVE_HOME} hive && \
     chown hive:hive -R ${HIVE_HOME} && \
-    chown hive:hive -R /prometheus  && \
+    chown hive:hive -R /opt/prometheus  && \
     chown hive:hive /metastore.sh && chmod +x /metastore.sh
 
 # Security breach, but must be in a namespace with relaxed psp to be able to sudo
 COPY docker/hive.sudoer /etc/sudoers.d/hive
 
-USER 1000
+USER 996
 
-ENV HADOOP_OPTS="$HADOOP_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9026 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/prometheus/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar=${JMX_PORT}:/prometheus/config.yaml"
+ENV HADOOP_OPTS="$HADOOP_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9026 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/opt/prometheus/jmx_prometheus_javaagent-${JMX_PROMETHEUS_JAVAAGENT_VERSION}.jar=${JMX_PORT}:/opt/prometheus/config.yaml"
 
 EXPOSE 9083
 EXPOSE ${JMX_PORT}

--- a/helm/hive-metastore/README.md
+++ b/helm/hive-metastore/README.md
@@ -76,7 +76,7 @@ $ helm pull oci://quay.io/okdp/charts/hive-metastore --version 3.1.3-1.2.0
 	</thead>
 	<tbody>
 		<tr>
-			<td id="affinity"><a href="./values.yaml#L144">affinity</a></td>
+			<td id="affinity"><a href="./values.yaml#L145">affinity</a></td>
 			<td>
 object
 </td>
@@ -130,7 +130,7 @@ null
 			<td>S3 IAM role ARN for hive-metastore access to S3.</td>
 		</tr>
 		<tr>
-			<td id="commonAnnotations"><a href="./values.yaml#L153">commonAnnotations</a></td>
+			<td id="commonAnnotations"><a href="./values.yaml#L154">commonAnnotations</a></td>
 			<td>
 object
 </td>
@@ -142,7 +142,7 @@ object
 			<td>Annotations to be added to all resources.</td>
 		</tr>
 		<tr>
-			<td id="containerSecurityContext--allowPrivilegeEscalation"><a href="./values.yaml#L133">containerSecurityContext.allowPrivilegeEscalation</a></td>
+			<td id="containerSecurityContext--allowPrivilegeEscalation"><a href="./values.yaml#L134">containerSecurityContext.allowPrivilegeEscalation</a></td>
 			<td>
 bool
 </td>
@@ -154,7 +154,7 @@ false
 			<td></td>
 		</tr>
 		<tr>
-			<td id="containerSecurityContext--capabilities--drop[0]"><a href="./values.yaml#L137">containerSecurityContext.capabilities.drop[0]</a></td>
+			<td id="containerSecurityContext--capabilities--drop[0]"><a href="./values.yaml#L138">containerSecurityContext.capabilities.drop[0]</a></td>
 			<td>
 string
 </td>
@@ -166,7 +166,7 @@ string
 			<td></td>
 		</tr>
 		<tr>
-			<td id="containerSecurityContext--readOnlyRootFilesystem"><a href="./values.yaml#L134">containerSecurityContext.readOnlyRootFilesystem</a></td>
+			<td id="containerSecurityContext--readOnlyRootFilesystem"><a href="./values.yaml#L135">containerSecurityContext.readOnlyRootFilesystem</a></td>
 			<td>
 bool
 </td>
@@ -274,7 +274,7 @@ null
 			<td>Hive metastore database existing kubernetes secret name.</td>
 		</tr>
 		<tr>
-			<td id="deploymentName"><a href="./values.yaml#L163">deploymentName</a></td>
+			<td id="deploymentName"><a href="./values.yaml#L164">deploymentName</a></td>
 			<td>
 string
 </td>
@@ -318,7 +318,7 @@ object
 </td>
 		</tr>
 		<tr>
-			<td id="fullNameOverride"><a href="./values.yaml#L161">fullNameOverride</a></td>
+			<td id="fullNameOverride"><a href="./values.yaml#L162">fullNameOverride</a></td>
 			<td>
 string
 </td>
@@ -330,7 +330,7 @@ null
 			<td>Allow overriding base name of all resources.</td>
 		</tr>
 		<tr>
-			<td id="hpaName"><a href="./values.yaml#L171">hpaName</a></td>
+			<td id="hpaName"><a href="./values.yaml#L172">hpaName</a></td>
 			<td>
 string
 </td>
@@ -404,7 +404,7 @@ object
 			<td>Hive metastore database initialization job</td>
 		</tr>
 		<tr>
-			<td id="jobName"><a href="./values.yaml#L165">jobName</a></td>
+			<td id="jobName"><a href="./values.yaml#L166">jobName</a></td>
 			<td>
 string
 </td>
@@ -428,7 +428,7 @@ string
 			<td>Log4j2 log level. One of `` `debug`, `info`, `warn`, `error`, `fatal`, `trace`</td>
 		</tr>
 		<tr>
-			<td id="nameOverride"><a href="./values.yaml#L159">nameOverride</a></td>
+			<td id="nameOverride"><a href="./values.yaml#L160">nameOverride</a></td>
 			<td>
 string
 </td>
@@ -476,7 +476,7 @@ true
 			<td></td>
 		</tr>
 		<tr>
-			<td id="networkPolicyName"><a href="./values.yaml#L169">networkPolicyName</a></td>
+			<td id="networkPolicyName"><a href="./values.yaml#L170">networkPolicyName</a></td>
 			<td>
 string
 </td>
@@ -488,7 +488,7 @@ null
 			<td>Will default to {{ include "metastore.fullname" . }}</td>
 		</tr>
 		<tr>
-			<td id="nodeSelector"><a href="./values.yaml#L140">nodeSelector</a></td>
+			<td id="nodeSelector"><a href="./values.yaml#L141">nodeSelector</a></td>
 			<td>
 object
 </td>
@@ -500,7 +500,7 @@ object
 			<td>Node selector for the hive-metastore pod.</td>
 		</tr>
 		<tr>
-			<td id="podAnnotations"><a href="./values.yaml#L150">podAnnotations</a></td>
+			<td id="podAnnotations"><a href="./values.yaml#L151">podAnnotations</a></td>
 			<td>
 object
 </td>
@@ -520,6 +520,7 @@ object
 <pre lang="json">
 {
   "runAsNonRoot": true,
+  "runAsUser": 996,
   "seccompProfile": {
     "type": "RuntimeDefault"
   }
@@ -677,7 +678,7 @@ object
 			<td>Specifies whether a service account should be created.</td>
 		</tr>
 		<tr>
-			<td id="serviceName"><a href="./values.yaml#L167">serviceName</a></td>
+			<td id="serviceName"><a href="./values.yaml#L168">serviceName</a></td>
 			<td>
 string
 </td>
@@ -689,7 +690,7 @@ null
 			<td>Will default to {{ include "metastore.fullname" . }}</td>
 		</tr>
 		<tr>
-			<td id="servicePort"><a href="./values.yaml#L147">servicePort</a></td>
+			<td id="servicePort"><a href="./values.yaml#L148">servicePort</a></td>
 			<td>
 int
 </td>
@@ -701,7 +702,7 @@ int
 			<td>Hive metastore service port.</td>
 		</tr>
 		<tr>
-			<td id="tolerations"><a href="./values.yaml#L142">tolerations</a></td>
+			<td id="tolerations"><a href="./values.yaml#L143">tolerations</a></td>
 			<td>
 list
 </td>

--- a/helm/hive-metastore/values.yaml
+++ b/helm/hive-metastore/values.yaml
@@ -126,6 +126,7 @@ serviceAccount:
 # -- Security profile for the hive-metastore pod.
 podSecurityContext:
   runAsNonRoot: true
+  runAsUser: 996
   seccompProfile:
     type: RuntimeDefault
 


### PR DESCRIPTION
This pull request provides the upgrade for the base image of the Dockerfile. 


FROM eclipse-temurin:19-jre-focal ===> FROM eclipse-temurin:17-jre-noble


This also comes with additional configurations for both the Dockerfile and helm chart:

**CRITICAL**

- UID 1000 is reserved for user ubuntu, so a new UID/GID is created for the user hive(996).
- hadoop and mysql connector versions were changed to better match compatibility with the new version.
- A hotfix was added for the hadoop component in order to bypass a bug behaviour when the start-metastore tool is using the hadoop binary.

**MEDIUM**
- Added "runAsUser: 996" in the podSecurityContext inside the values.yaml file.
- Updated system packages, runtime tools, and environment variables.

Follows up https://github.com/OKDP/hive-metastore/issues/44