### PR TITLE
fix(docker): use mysql client major version instead of Ubuntu revision

### DIFF
--- a/.github/workflows/docker-build-test-push-template.yml
+++ b/.github/workflows/docker-build-test-push-template.yml
@@ -23,7 +23,7 @@ on:
         description: Docker context
         required: false
         type: string
-        default: '.'
+        default: "."
       dockerfile:
         description: Dockerfile path
         required: true
@@ -32,23 +32,23 @@ on:
         description: Image name
         required: false
         type: string
-        default: 'hive-metastore'
+        default: "hive-metastore"
       publish_to_registry:
-        description: Wheter to push to the registry
+        description: Whether to push to the official registry
         required: false
         type: string
         default: "false"
       registry:
-        description: The container registry
+        description: The official container registry
         required: false
         type: string
       ci_registry:
-        description: "The registry used to push ci images"
+        description: The registry used to push CI images
         required: false
         type: string
         default: "ghcr.io"
       metastore_version:
-        description: "Hive metastore version"
+        description: Hive metastore version
         required: true
         type: string
       git_latest_release_tag:
@@ -57,14 +57,18 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+  packages: write
+
 defaults:
   run:
     shell: bash
 
 jobs:
-
   docker-build-test-push:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout latest Github Release tag (${{ inputs.git_latest_release_tag }}) ⚡️
         if: inputs.publish_to_registry == 'true'
@@ -72,7 +76,6 @@ jobs:
         with:
           ref: ${{ inputs.git_latest_release_tag }}
 
-      ### The CI is based on the main branch
       - name: Checkout Repo ⚡️
         if: inputs.publish_to_registry == 'false'
         uses: actions/checkout@v6
@@ -80,20 +83,34 @@ jobs:
       - name: Set up CI and official registries 📦
         id: registry
         run:  |
-          echo "repo_owner=${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-          echo "ci_repo=${{ inputs.ci_registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-          echo "publish_repo=${{ inputs.registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-        shell: bash
+          echo "repo_owner=${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
+          echo "ci_repo=${{ inputs.ci_registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
+          echo "publish_repo=${{ inputs.registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate CI push policy 🔎
+        id: push-policy
+        run: |
+          can_push_ci=true
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            head_repo="$(jq -r '.pull_request.head.repo.full_name // ""' "$GITHUB_EVENT_PATH")"
+
+            if [[ "$head_repo" != "$GITHUB_REPOSITORY" ]]; then
+              can_push_ci=false
+            fi
+          fi
+
+          echo "can_push_ci=$can_push_ci" >> "$GITHUB_OUTPUT"
 
       - name: Login to the CI registry 🔐
-        if: inputs.publish_to_registry == 'false'
+        if: inputs.publish_to_registry == 'false' && steps.push-policy.outputs.can_push_ci == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.ci_registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login into official registry 🔐
+      - name: Login to official registry 🔐
         if: inputs.publish_to_registry == 'true'
         uses: docker/login-action@v3
         with:
@@ -121,22 +138,23 @@ jobs:
         run: |
           branch="${{ steps.get-branch.outputs.branch }}"
           release="${{ inputs.git_latest_release_tag }}"
+
           if [[ -n "$branch" ]]; then
             tag="${branch//\//--}"
           else
             tag="${release#v}"
           fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-        shell: bash
 
-      - name: Build and push image ${{ steps.registry.outputs.ci_repo }}/${{ inputs.image }} (${{ inputs.metastore_version }}) 📤
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push CI image ${{ steps.registry.outputs.ci_repo }}/${{ inputs.image }} (${{ inputs.metastore_version }}) 📤
         if: inputs.publish_to_registry == 'false'
         uses: docker/build-push-action@v5
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ steps.push-policy.outputs.can_push_ci == 'true' }}
           tags: |
             ${{ steps.registry.outputs.ci_repo }}/${{ inputs.image }}:${{ inputs.metastore_version }}-${{ steps.image-tag.outputs.tag }}
           labels: |
@@ -146,7 +164,7 @@ jobs:
           build-args: |
             ARG_METASTORE_VERSION=${{ inputs.metastore_version }}
 
-      - name: Build and push image ${{ steps.registry.outputs.publish_repo }}/${{ inputs.image }} (${{ inputs.metastore_version }}) 📤
+      - name: Build and push official image ${{ steps.registry.outputs.publish_repo }}/${{ inputs.image }} (${{ inputs.metastore_version }}) 📤
         if: inputs.publish_to_registry == 'true'
         uses: docker/build-push-action@v5
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ ARG ARG_HADOOP_VERSION=3.3.6
 ARG ARG_METASTORE_VERSION=3.1.3
 ARG ARG_JDBC_VERSION=42.7.7
 ARG MYSQL_CONNECTOR_VERSION=8.0.25
-ARG ARG_MYSQL_CLIENT_VERSION=8.0.44-0ubuntu0.24.04.1
+ARG ARG_MYSQL_CLIENT_VERSION=8.0
 ARG LOG4J_SCANNER_VERSION=2.25.0
 ARG JMX_PROMETHEUS_JAVAAGENT_VERSION=1.0.1
 ARG JMX_PORT=9025
@@ -51,7 +51,7 @@ RUN apt-get update && \
     postgresql-client \
     sudo \
     curl \
-    mysql-client=${MYSQL_CLIENT_VERSION} && \
+    mysql-client-${MYSQL_CLIENT_VERSION} && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives
 


### PR DESCRIPTION
## Description

This PR fixes two Docker/CI issues:

1. Changes the MySQL client version argument from a full Ubuntu package revision to the MySQL client major version.

Before:

```dockerfile
ARG ARG_MYSQL_CLIENT_VERSION=8.0.45-0ubuntu0.24.04.1
```

After:

```dockerfile
ARG ARG_MYSQL_CLIENT_VERSION=8.0
```

The Dockerfile uses this value to install:

```dockerfile
mysql-client-${MYSQL_CLIENT_VERSION}
```

which resolves to:

```text
mysql-client-8.0
```

This avoids tying the Docker build to a specific Ubuntu package revision while keeping the intended MySQL 8.0 client package. It also allows APT to pick up the currently available Ubuntu package revision, including security and patch updates, instead of remaining stuck on a fixed revision.

2. Updates the Docker CI workflow to handle pull requests from forked repositories safely.

For same-repository pull requests, the workflow can still log in to the CI registry and push CI images.

For pull requests opened from forked repositories, the workflow now skips registry login and disables image push. This avoids failures caused by the read-only `GITHUB_TOKEN` and unavailable secrets on forked pull requests, while still allowing the Docker build itself to run.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / chore
* [ ] Breaking change

## How to Test

1. Build the Docker image locally:

   ```bash
   docker build -t hive-metastore:test -f docker/Dockerfile .
   ```

2. Verify that the build resolves and installs the MySQL client package:

   ```bash
   docker run --rm hive-metastore:test mysql --version
   ```

3. Verify that the installed package is from the MySQL 8.0 client package:

   ```bash
   docker run --rm hive-metastore:test dpkg -l | grep mysql-client
   ```

4. Verify that the Docker build no longer depends on the unavailable exact Ubuntu package revision.

5. Verify the CI workflow behavior for pull requests:

   * For a same-repository pull request, the workflow can log in to the CI registry and push the CI image.
   * For a pull request from a forked repository, the workflow skips CI registry login and runs the Docker build with image push disabled.

## Checklist

* [x] I have tested my changes
* [x] Documentation updated if needed
* [ ] If breaking change: migration path described above
* [x] I hereby declare this contribution to be licensed under the [[Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)](http://www.apache.org/licenses/LICENSE-2.0).
* [x] I hereby agree to grant [[TOSIT](https://www.tosit.io/)](https://www.tosit.io/) a copyright license to use my contributions.