### PR TITLE
ci(trivy): scan published metastore images on schedule, after first version build or rebuild

### DIFF
--- a/.github/actions/trivy-versions/action.yml
+++ b/.github/actions/trivy-versions/action.yml
@@ -1,0 +1,137 @@
+#
+# Copyright 2026 The OKDP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Build Trivy image matrix"
+description: "Builds the Hive Metastore image matrix used by Trivy scans"
+
+inputs:
+  registry:
+    description: "Container registry"
+    required: false
+    default: "quay.io"
+
+  repository_owner:
+    description: "Repository owner / registry namespace"
+    required: true
+
+  package_file:
+    description: "Path to package metadata containing the image name"
+    required: false
+    default: "docker/package.json"
+
+  version_file:
+    description: "Path to Hive Metastore version file"
+    required: false
+    default: "docker/metastore_4x.version"
+
+outputs:
+  metastore_versions:
+    description: "JSON array of Hive Metastore versions"
+    value: ${{ steps.metastore-versions.outputs.metastore_versions }}
+
+  image_tags:
+    description: "JSON matrix of container image tags to scan"
+    value: ${{ steps.trivy-versions.outputs.image_tags }}
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Get Metastore versions
+      id: metastore-versions
+      uses: ./.github/actions/metastore-versions
+
+    - name: Build Trivy image matrix
+      id: trivy-versions
+      shell: bash
+      env:
+        METASTORE_VERSIONS: ${{ steps.metastore-versions.outputs.metastore_versions }}
+        REGISTRY: ${{ inputs.registry }}
+        REPOSITORY_OWNER: ${{ inputs.repository_owner }}
+        PACKAGE_FILE: ${{ inputs.package_file }}
+        VERSION_FILE: ${{ inputs.version_file }}
+      run: |
+        set -euo pipefail
+
+        image_name="$(jq -r '.name' "$PACKAGE_FILE")"
+        repository_owner="$(printf '%s' "$REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+        image_repository="$REGISTRY/$repository_owner/$image_name"
+
+        metastore_versions_file="$(mktemp)"
+        image_tags_file="$(mktemp)"
+
+        jq -r '.[]' <<< "$METASTORE_VERSIONS" | sort -u > "$metastore_versions_file"
+
+        if [[ ! -s "$metastore_versions_file" ]]; then
+          echo "No metastore versions found"
+          exit 1
+        fi
+
+        while IFS= read -r metastore_version; do
+          image_tag="$metastore_version"
+
+          jq -n \
+            --arg image "$image_repository:$image_tag" \
+            --arg image_tag "$image_tag" \
+            --arg metastore_version "$metastore_version" \
+            --arg github_tag "" \
+            '{
+              image: $image,
+              image_tag: $image_tag,
+              metastore_version: $metastore_version,
+              github_tag: $github_tag
+            }' >> "$image_tags_file"
+
+          # Docker release tags are root tags like:
+          #   v1.4.0
+          #   v3.1.3-1.3.0
+          #
+          # Helm tags are intentionally ignored because they are namespaced:
+          #   helm-hive-metastore/v1.4.0
+          #
+          # git tag --list 'v*' only matches tags starting with v,
+          # so it excludes helm-hive-metastore/v* tags.
+          while IFS= read -r github_tag; do
+            if file_content="$(git show "$github_tag:$VERSION_FILE" 2>/dev/null)"; then
+              tag_versions="$(
+                sed -n 's/.*ARG_METASTORE_VERSION=\([0-9.][0-9.]*\).*/\1/p' <<< "$file_content"
+              )"
+
+              if grep -Fxq "$metastore_version" <<< "$tag_versions"; then
+                registry_tag="${github_tag#v}"
+                image_tag="$metastore_version-$registry_tag"
+
+                jq -n \
+                  --arg image "$image_repository:$image_tag" \
+                  --arg image_tag "$image_tag" \
+                  --arg metastore_version "$metastore_version" \
+                  --arg github_tag "$github_tag" \
+                  '{
+                    image: $image,
+                    image_tag: $image_tag,
+                    metastore_version: $metastore_version,
+                    github_tag: $github_tag
+                  }' >> "$image_tags_file"
+              fi
+            fi
+          done < <(git tag --list 'v*' --sort=version:refname)
+        done < "$metastore_versions_file"
+
+        image_tags="$(jq -s -c 'unique_by(.image)' "$image_tags_file")"
+
+        echo "$image_tags"
+        echo "image_tags=$image_tags" >> "$GITHUB_OUTPUT"
+        

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,11 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "chore(update)"
+
+  - package-ecosystem: "github-actions"
+    # Applies to all workflow files under .github/workflows/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(update)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ on:
       - "!.release-please-manifest.json"
 
   workflow_dispatch:
-  
+
 permissions:
   contents: write
   packages: write
@@ -67,10 +67,12 @@ jobs:
 
   metastore-versions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       metastore_versions: ${{ steps.parse.outputs.metastore_versions }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get metastore versions
         id: parse
@@ -92,6 +94,3 @@ jobs:
   helm-lint:
     name: helm-lint
     uses: ./.github/workflows/helm-lint-template.yml
-
-
-

--- a/.github/workflows/docker-build-test-push-template.yml
+++ b/.github/workflows/docker-build-test-push-template.yml
@@ -72,13 +72,13 @@ jobs:
     steps:
       - name: Checkout latest Github Release tag (${{ inputs.git_latest_release_tag }}) ⚡️
         if: inputs.publish_to_registry == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.git_latest_release_tag }}
 
       - name: Checkout Repo ⚡️
         if: inputs.publish_to_registry == 'false'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up CI and official registries 📦
         id: registry
@@ -104,7 +104,7 @@ jobs:
 
       - name: Login to the CI registry 🔐
         if: inputs.publish_to_registry == 'false' && steps.push-policy.outputs.can_push_ci == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ inputs.ci_registry }}
           username: ${{ github.actor }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Login to official registry 🔐
         if: inputs.publish_to_registry == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Build and push CI image ${{ steps.registry.outputs.ci_repo }}/${{ inputs.image }} (${{ inputs.metastore_version }}) 📤
         if: inputs.publish_to_registry == 'false'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -166,7 +166,7 @@ jobs:
 
       - name: Build and push official image ${{ steps.registry.outputs.publish_repo }}/${{ inputs.image }} (${{ inputs.metastore_version }}) 📤
         if: inputs.publish_to_registry == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -39,22 +39,25 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: read
   packages: write
-  
+
 jobs:
 
   latest-github-release:
     if: github.repository_owner == 'OKDP'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tag_name: ${{ steps.git-release-tag.outputs.tag }}
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get latest GitHub Release tag name 📥
         id: git-release-tag
-        uses: oprypin/find-latest-tag@v1
+        uses: oprypin/find-latest-tag@eaa889b9a4a9be89c2f71b46894b5607ba01eae4 # v1.1.3
         with:
           repository: ${{ github.repository }}
           releases-only: true
@@ -68,11 +71,13 @@ jobs:
   metastore-versions:
     needs: [latest-github-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       metastore_versions: ${{ steps.parse.outputs.metastore_versions }}
       git_latest_release_tag: ${{ needs.latest-github-release.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.latest-github-release.outputs.tag_name }}
       - name: Get metastore versions
@@ -98,5 +103,5 @@ jobs:
       metastore_version: ${{ matrix.metastore-version }}
       publish_to_registry: "true"
       registry: ${{ vars.REGISTRY || 'quay.io' }}
-      git_latest_release_tag: ${{ needs.latest-github-release.outputs.git_latest_release_tag }}
+      git_latest_release_tag: ${{ needs.metastore-versions.outputs.git_latest_release_tag }}
     secrets: inherit

--- a/.github/workflows/helm-lint-template.yml
+++ b/.github/workflows/helm-lint-template.yml
@@ -33,23 +33,25 @@ jobs:
 
   helm-lint:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Setup helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.15.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Run chart-testing (list-changed) ✅
         id: list-changed
@@ -90,7 +92,7 @@ jobs:
         if: |
           ${{ ((github.event_name == 'push') || (github.event_name == 'pull_request'
                 && github.event.pull_request.head.repo.full_name == github.repository)) }}
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@777a761e0f8293b7b051170404976d7cf10611cb # v9.1.4
         with:
           pull: "--rebase --autostash"
           add: "**/README.md"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,6 +37,10 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     outputs:
       docker-release_created: ${{ steps.release-please.outputs.docker--release_created }}
       docker-tag_name: ${{ steps.release-please.outputs.docker--tag_name }}
@@ -48,16 +52,18 @@ jobs:
     # The pull request should come from the same repo (github_token from the fork does not have write permissions)
     if: github.repository_owner == 'OKDP' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release-please
 
   metastore-versions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       metastore_versions: ${{ steps.parse.outputs.metastore_versions }}
       git_latest_release_tag: ${{ needs.release-please.outputs.docker-tag_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.release-please.outputs.docker-tag_name }}
       - name: Get metastore versions
@@ -98,4 +104,4 @@ jobs:
       version: ${{ needs.release-please.outputs.helm-version }}
       git_tag_name: ${{ needs.release-please.outputs.helm-tag_name }}
     secrets: inherit
-                
+

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,13 +43,15 @@ jobs:
         github.event.workflow_run.conclusion == 'success'
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     outputs:
       image_tags: ${{ steps.trivy-versions.outputs.image_tags }}
 
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -78,7 +80,7 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: ${{ matrix.image }}
           format: sarif
@@ -86,8 +88,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@1a818fd5f97ed0ee9a823421bd5b171add01227f # v4.36.2
         with:
           sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
           category: trivy-hive-metastore-${{ matrix.image_tag }}
-

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2026 The OKDP Authors.
+# Copyright 2025 The OKDP Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,16 @@
 name: Trivy Scan
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - docker-rebuild
+      - release-please
+    types:
+      - completed
+    branches:
+      - main
+
   schedule:
     - cron: '0 12 * * *'
 
@@ -28,36 +34,60 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  image-tags:
+    if: >-
+      github.repository_owner == 'OKDP' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule' ||
+        github.event.workflow_run.conclusion == 'success'
+      )
+    runs-on: ubuntu-latest
+
+    outputs:
+      image_tags: ${{ steps.trivy-versions.outputs.image_tags }}
+
+    steps:
+      - name: Checkout Repo ⚡️
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get Trivy image matrix
+        id: trivy-versions
+        uses: ./.github/actions/trivy-versions
+        with:
+          registry: ${{ vars.REGISTRY || 'quay.io' }}
+          repository_owner: ${{ github.repository_owner }}
+
+  trivy-scan:
+    needs: [image-tags]
+    if: github.repository_owner == 'OKDP'
     permissions:
       contents: read
       security-events: write
       actions: read
-    name: Build
+
+    name: Scan ${{ matrix.image_tag }}
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.image-tags.outputs.image_tags) }}
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Get image information
-        id: get-image-info
-        run: |
-          IMAGE_NAME=$(jq -r '.name' docker/package.json)
-          IMAGE_VERSION=$(jq -r '.version' docker/package.json)
-          echo $IMAGE_NAME
-          echo $IMAGE_VERSION
-          echo "IMAGE=quay.io/okdp/$IMAGE_NAME:$IMAGE_VERSION" >> $GITHUB_ENV
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
         with:
-          image-ref: '${{ env.IMAGE }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: trivy-results-${{ matrix.image_tag }}.sarif
+          severity: CRITICAL,HIGH
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: trivy-results-${{ matrix.image_tag }}.sarif
+          category: trivy-hive-metastore-${{ matrix.image_tag }}
+

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
## Description

This PR updates the Trivy scan workflow to scan published Hive Metastore container images from the version matrix declared in `docker/metastore_4x.version`.

It adds a reusable local `trivy-versions` action that reuses the existing `metastore-versions` action to build the Trivy scan matrix.

The generated scan matrix includes:

* base Metastore image tags, for example `quay.io/okdp/hive-metastore:4.0.1`
* release-suffixed image tags, for example `quay.io/okdp/hive-metastore:4.0.1-1.4.0`

Release-suffixed image tags are only added when the corresponding GitHub release tag contains the same Metastore version in its historical `docker/metastore_4x.version` file. This avoids scanning non-existing combinations such as a new Metastore image version combined with an older GitHub release tag.

Helm-prefixed Git tags are ignored when building the Trivy scan matrix.

The workflow also supports manual execution with `workflow_dispatch`, scheduled scans, and scans after successful `docker-rebuild` and `release-please` workflow completions.

Also, all workflow files have been hardened against over-privileged tokens and the third-party actions are now pinned to their [full commit SHA](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions).

## Related Issue

The previous scan logic could target incorrect image tags such as quay.io/okdp/hive-metastore:1.4.0, where 1.4.0 is the OKDP release version, not the Hive Metastore image version.

This caused Trivy to fail with MANIFEST_UNKNOWN when the generated image tag did not exist in Quay.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / chore
* [ ] Breaking change

## How to Test

1. Run the Trivy workflow manually from the GitHub Actions UI.
2. Verify that the generated scan matrix contains image tags based on `docker/metastore_4x.version`.
3. Verify that GitHub release tags keep the `v` prefix, while Quay image tags remove it.
4. Verify that Helm-prefixed Git tags such as `helm-hive-metastore/v...` are not included in the scan matrix.
5. Verify that release-suffixed image tags are generated only when the matching Metastore version existed in the historical `docker/metastore_4x.version` file for that GitHub tag.
6. Verify that Trivy uploads SARIF results to GitHub Code Scanning.

## Checklist

* [x] I have tested my changes
* [x] Documentation updated if needed
* [x] If breaking change: migration path described above
* [x] I hereby declare this contribution to be licensed under the [[Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)](http://www.apache.org/licenses/LICENSE-2.0).
* [x] I hereby agree to grant [[TOSIT](https://www.tosit.io/)](https://www.tosit.io/) a copyright license to use my contributions.