### PR TITLE
ci: disable dependabot version update PRs (enable security alerts only)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
     directory: "/docker"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore(update)"
 
@@ -28,5 +29,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore(update)"


### PR DESCRIPTION
see https://github.com/OKDP/OKDP/issues/27
